### PR TITLE
Changed name to yielding-executor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "yielding-async-executor"
+name = "yielding-executor"
 version = "0.10.0"
 authors = [
   "Yurii Rashkovskii <yrashk@gmail.com>",
@@ -8,10 +8,10 @@ authors = [
 edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "Async executor with configurable yielding"
-repository = "https://github.com/vinodotdev/async-executor"
-documentation = "https://docs.rs/yielding-async-executor"
+repository = "https://github.com/wasmflow/yielding-executor"
+documentation = "https://docs.rs/yielding-executor"
 readme = "README.md"
-keywords = ["wasm", "async"]
+keywords = ["wasm", "async", "yield"]
 
 [lib]
 crate-type = ["cdylib", "lib"]
@@ -21,7 +21,6 @@ futures = { version = "0.3", features = ["std"] }
 pin-project = { version = "1.0" }
 
 [target.wasm32-unknown-unknown.dependencies]
-
 
 [target.wasm32-unknown-unknown.dev-dependencies]
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Yielding Async Executor for WebAssembly
+# Yielding Executor for WebAssembly
 
-[![Crate](https://img.shields.io/crates/v/yielding-async-executor.svg)](https://crates.io/crates/yielding-async-executor)
-[![API](https://docs.rs/yielding-async-executor/badge.svg)](https://docs.rs/yielding-async-executor)
+[![Crate](https://img.shields.io/crates/v/yielding-executor.svg)](https://crates.io/crates/yielding-executor)
+[![API](https://docs.rs/yielding-executor/badge.svg)](https://docs.rs/yielding-executor)
 
 This executor is a fork of [wasm-rs-async-executor](https://github.com/wasm-rs/async-executor) decoupled from wasm-bindgen.
 
@@ -17,10 +17,10 @@ Include this dependency in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-yielding-async-executor = "0.9.0"
+yielding-executor = "0.9.0"
 ```
 
-`yielding-async-executor` is expected to work on stable Rust, 1.49.0 and higher up.
+`yielding-executor` is expected to work on stable Rust, 1.49.0 and higher up.
 
 ## Supported targets
 

--- a/src/single_threaded.rs
+++ b/src/single_threaded.rs
@@ -10,7 +10,7 @@
 //!
 //! ```
 //! use tokio::sync::*;
-//! use wasm_rs_async_executor::single_threaded::{spawn, run};
+//! use yielding_executor::single_threaded::{spawn, start};
 //! let (sender, receiver) = oneshot::channel::<()>();
 //! let _task = spawn(async move {
 //!    // Complete when something is received
@@ -18,7 +18,7 @@
 //! });
 //! // Send data to be received
 //! let _ = sender.send(());
-//! run(None);
+//! start();
 //! ```
 use futures::channel::oneshot;
 use futures::task::{waker_ref, ArcWake};


### PR DESCRIPTION
Can't publish crates that rely on git dependencies so I'm publishing this as `yielding-executor`. It may be worth upstreaming this to the original repository but we're not ready for that yet.